### PR TITLE
Added Seller Information on recycler view items and detailed view

### DIFF
--- a/app/src/main/java/com/codepath/bibliophile/adapter/HomeRecyclerViewAdapter.java
+++ b/app/src/main/java/com/codepath/bibliophile/adapter/HomeRecyclerViewAdapter.java
@@ -3,7 +3,6 @@ package com.codepath.bibliophile.adapter;
 import android.content.Context;
 import android.content.Intent;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -40,7 +39,20 @@ public class HomeRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.V
         private RatingBar tvRating;
         private TextView tvBookDescription;
         private TextView tvPrice;
+        private TextView tvBookOwner;
         private View view;
+
+        public TextView getTvBookOwner() {
+            return tvBookOwner;
+        }
+
+        public void setTvBookOwner(TextView tvBookOwner) {
+            this.tvBookOwner = tvBookOwner;
+        }
+
+        public void setTvRating(RatingBar tvRating) {
+            this.tvRating = tvRating;
+        }
 
         public BookViewHolder(View itemView) {
             super(itemView);
@@ -51,6 +63,8 @@ public class HomeRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.V
             tvRating = (RatingBar) itemView.findViewById(R.id.rating);
             tvBookDescription = (TextView) itemView.findViewById(R.id.tvDescription);
             tvPrice = (TextView) itemView.findViewById(R.id.tvPrice);
+            tvBookOwner =(TextView) itemView.findViewById(R.id.tvBookOwner);
+
         }
         public View getView() { return view; }
         public ImageView getIvBookCover() {
@@ -123,7 +137,9 @@ public class HomeRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerView.V
             vh1.getTvBookDescription().setText(book.getDescription());
             vh1.getTvPrice().setText(book.getPrice().toString());
             vh1.getTvRating().setRating((float) book.getAverageRating().doubleValue());
-            Log.d(book.toString(), "onBindViewHolder: ");
+            vh1.getTvBookOwner().setText(book.getBookOwner());
+
+
 
             if (book.getBookCover() != null) {
                 vh1.getIvBookCover().setVisibility(View.VISIBLE);

--- a/app/src/main/res/layout/home_recycler_view_item.xml
+++ b/app/src/main/res/layout/home_recycler_view_item.xml
@@ -121,5 +121,22 @@
             android:layout_alignBottom="@+id/tvLocation"
             android:layout_alignParentRight="true"
             android:layout_alignParentEnd="true" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/tvSeller"
+            android:text="Seller:"
+            android:layout_below="@+id/tvLocation"
+            android:layout_toRightOf="@+id/ivBookCover"
+            android:layout_toEndOf="@+id/ivBookCover" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/tvBookOwner"
+            android:text="Supriya Premkumar"
+            android:layout_below="@+id/tvLocation"
+            android:layout_toRightOf="@+id/tvAuthor"
+            android:layout_toEndOf="@+id/tvAuthor" />
     </RelativeLayout>
 </android.support.v7.widget.CardView>


### PR DESCRIPTION
This change adds seller information on recycler view items. We also propagate these to detailedview.

As a sidenote, the Book Model expects a valid _User pointer. If we delete a user BookModel will not be able to de-reference _User Pointer and will crash.
I have deleted the stale books model documents. (a.k.a the one without any valid owners)
So everything is working now.

As a better measure, we will have to add some more sanity checking.

Verified that this works on both Android phone and on genymotion.
