### PR TITLE
Completed all transaction workflows.

### DIFF
--- a/app/src/main/java/com/codepath/bibliophile/fragment/BookShelfFragment.java
+++ b/app/src/main/java/com/codepath/bibliophile/fragment/BookShelfFragment.java
@@ -151,6 +151,7 @@ public class BookShelfFragment extends Fragment {
                                         book.saveEventually();
                                     } else {
                                         book.setIsListed(true);
+                                        book.setIsTransactionComplete(false);
                                         ivListingIcon.setImageResource(R.drawable.ic_unlist);
                                         tvListingStatus.setText("Unlist");
                                         book.saveEventually();


### PR DESCRIPTION
This change marks the completion of transaction workflows. Here are the user scenarios it supports.
Seller: Supriya
Buyer: Bobby
1. Supriya lists the book using barcode/isbn entry. The book will show up in her BookShelf, but not on her home time line.
2. The book will show up on Bobby's timeline where he can buy. He clicks Buy button. The book will be now visible in Transactions page of both Supriya and Bobby.

Tested Possible workflows:
3. On transactions page, Supriya clicks Cancel Transaction. The book is immediately moved out of transactions and into homepage. Bobby is no longer the buyer.
4. Repeat 1 and 2. Now Bobby clicks decline and the same thing happens. Bobby is no longer the buyer.
5. Both Bobby and Supriya click confirm transaction. The book is immediately moved from the transactions of whoever clicks confirm at the end and we swap the buyer and seller and by default we will not list the book with Bobby as seller. (Probably Bobby wants to read the book which he just bought  :-D )

This closes https://github.com/CodepathFinalProject/Bibliophile/issues/28
